### PR TITLE
autoclose postMessage to opener

### DIFF
--- a/themes/_global/js/autoClose.js
+++ b/themes/_global/js/autoClose.js
@@ -1,6 +1,26 @@
 $(document).ready(function() {
 	current_url = window.location.href
 	if (current_url.match("&closewin=true")) {
+		if (opener) {
+			var msgDiv = $("div.messages");
+			var msg = msgDiv.children("p").text();
+			var status = msgDiv.hasClass("success") ?
+				'success' : 'unknown';
+			/* TODO
+			 * I would also like to send the link back
+			 * but the first link e.g. $(".tool.link")[0]
+			 * may not be the right way to find it:
+			 * We also get a "success" when the item is
+			 * already stored. In this case the item
+			 * will be sorted to the top.
+			 * Are there other cases where we get a
+			 * success but the url is not on top?!
+			*/
+			var url = $(".tool.link")[0].href;
+			opener.postMessage({"wallabag-status": status,
+				"wallabag-msg": msg,
+				"wallabag-url": url }, "*");
+		}
 		window.close();
 	}
 });


### PR DESCRIPTION
This comes in handy when using another webapp that uses `window.open` to delegate adding to the wallabag site.

I'm using this (but not strictly requiring it) in the Firefox OS app.
